### PR TITLE
Make overlay transparent and shrink delete icon

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -356,3 +356,17 @@ img{
 .icon-bubble--warn{ background:linear-gradient(180deg, #FFF7E6, #FFE9B8); }
 .icon-bubble--info{ background:linear-gradient(180deg, #E8F4FF, #D6ECFF); }
 
+/* Ensure overlay is always transparent */
+.overlay {
+  background: transparent;
+  opacity: 1;
+}
+
+.overlay:hover {
+  background: transparent;
+}
+
+/* Make delete icon half as wide */
+.delete-icon {
+  transform: scaleX(0.5);
+}


### PR DESCRIPTION
## Summary
- ensure overlay remains transparent with no hover effect
- shrink delete icon width using horizontal scale

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a07a329124832cbca9dfe5d4bcaeba