### PR TITLE
Make overlay transparent and shrink delete icon

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -356,3 +356,17 @@ img{
 .icon-bubble--warn{ background:linear-gradient(180deg, #FFF7E6, #FFE9B8); }
 .icon-bubble--info{ background:linear-gradient(180deg, #E8F4FF, #D6ECFF); }
 
+/* Ensure overlay is always transparent */
+.overlay {
+  background: transparent;
+  opacity: 1;
+}
+
+.overlay:hover {
+  background: transparent;
+}
+
+/* Make delete icon half as wide */
+.delete-icon {
+  transform: scaleX(0.5);
+}

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -336,24 +336,25 @@ export default function Admin() {
                       alt={b.title}
                       className="badge-box rounded-full border object-cover"
                     />
-                    <Button
-                      className={
-                        "absolute inset-0 flex items-center justify-center text-xl text-white bg-transparent " +
-                        "hover:bg-black/30 rounded-full z-0"
-                      }
+                    <button
+                      type="button"
+                      className="absolute inset-0 flex items-center justify-center text-xl text-white rounded-full z-0"
                       onClick={() =>
                         document.getElementById(`edit-badge-image-${b.id}`).click()
                       }
+                      style={{ background: 'transparent' }}
                     >
                       ✏️
-                    </Button>
+                    </button>
                     <Button
                       className="absolute top-1 right-1 p-1 text-rose-600 bg-white/80 rounded-full text-xs z-10"
                       onClick={() => {
                         if (window.confirm('Badge verwijderen?')) removeBadge(b.id);
                       }}
                     >
-                      &#x2715;
+                      <span style={{ display: 'inline-block', transform: 'scaleX(0.5)' }}>
+                        &#x2715;
+                      </span>
                     </Button>
                   </div>
                   <div className="mt-2 text-center">


### PR DESCRIPTION
## Summary
- keep badge image edit overlay permanently transparent by using unstyled button
- narrow delete icon by scaling cross width to half

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a07a329124832cbca9dfe5d4bcaeba