### PR TITLE
Reduce delete icon width

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -366,7 +366,7 @@ img{
   background: transparent;
 }
 
-/* Make delete icon half as wide */
+/* Make delete icon one sixth as wide (one third of previous width) */
 .delete-icon {
-  transform: scaleX(0.5);
+  transform: scaleX(0.1667);
 }


### PR DESCRIPTION
## Summary
- reduce badge delete icon width to one third of its previous size for cleaner layout

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0850dc904832cba57449698a66b6a