### PR TITLE
Fix delete icon sizing

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -366,7 +366,8 @@ img{
   background: transparent;
 }
 
-/* Make delete icon one sixth as wide (one third of previous width) */
+/* Explicitly size delete icon instead of scaling */
 .delete-icon {
-  transform: scaleX(0.1667);
+  width: 12px;
+  height: 12px;
 }


### PR DESCRIPTION
## Summary
- Explicitly set width and height for `.delete-icon` so the delete icon renders smaller without relying on transforms

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08aff3b68832cb71344a4c624d157