### PR TITLE
chore: add react-app-rewired for webpack overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@vitejs/plugin-react": "^5.0.1",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
+        "react-app-rewired": "^2.2.1",
         "tailwindcss": "^3.4.17",
         "vite": "^7.1.3",
         "vite-plugin-svgr": "^4.5.0"
@@ -15539,6 +15540,32 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-app-rewired": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.2.1.tgz",
+      "integrity": "sha512-uFQWTErXeLDrMzOJHKp0h8P1z0LV9HzPGsJ6adOtGlA/B9WfT6Shh4j2tLTTGlXOfiVx6w6iWpp7SOC5pvk+gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.6.0"
+      },
+      "bin": {
+        "react-app-rewired": "bin/index.js"
+      },
+      "peerDependencies": {
+        "react-scripts": ">=2.1.3"
+      }
+    },
+    "node_modules/react-app-rewired/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "react-scripts": "5.0.1"
   },
   "scripts": {
-    "build": "react-scripts build",
-    "start": "react-scripts start"
+    "build": "react-app-rewired build",
+    "start": "react-app-rewired start"
   },
   "browserslist": {
     "production": [
@@ -30,6 +30,7 @@
     "@vitejs/plugin-react": "^5.0.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
+    "react-app-rewired": "^2.2.1",
     "tailwindcss": "^3.4.17",
     "vite": "^7.1.3",
     "vite-plugin-svgr": "^4.5.0"


### PR DESCRIPTION
## Summary
- install `react-app-rewired` to allow webpack custom config
- update start/build scripts to run through `react-app-rewired`

## Testing
- `BROWSER=none npm start`
- `npm run build` *(fails: Module not found: Error: Can't resolve 'buffer')*


------
https://chatgpt.com/codex/tasks/task_e_68aebc0ce4bc832ca5361a0e4abc2b82