### PR TITLE
Add .env config and super admin login

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+SMTP_HOST=smtp.strato.com
+SMTP_PORT=465
+SMTP_USER=info@minorneuro.nl
+SMTP_PASS=
+SMTP_FROM=info@minorneuro.nl
+PORT=3001
+
+SUPERADMIN_EMAIL=admin@nhlstenden.com
+SUPERADMIN_PASSWORD=neuro2025
+REACT_APP_SUPERADMIN_EMAIL=admin@nhlstenden.com
+REACT_APP_SUPERADMIN_PASSWORD=neuro2025

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "bcryptjs": "^2.4.3",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.1",
+        "dotenv": "^17.2.1",
         "express": "^4.19.2",
         "nodemailer": "^6.9.11",
         "process": "^0.11.10",
@@ -8190,12 +8191,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
@@ -15926,6 +15930,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
     "bcryptjs": "^2.4.3",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.1",
+    "dotenv": "^17.2.1",
+    "express": "^4.19.2",
+    "nodemailer": "^6.9.11",
     "process": "^0.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "stream-browserify": "^3.0.0",
-    "vm-browserify": "^1.1.2",
-    "express": "^4.19.2",
-    "nodemailer": "^6.9.11"
+    "vm-browserify": "^1.1.2"
   },
   "scripts": {
     "build": "react-app-rewired build",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const nodemailer = require('nodemailer');
 

--- a/src/App.js
+++ b/src/App.js
@@ -224,6 +224,9 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
   const [students, setStudents] = useStudents();
   const [teachers, setTeachers] = useTeachers();
 
+  const SUPER_ADMIN_EMAIL = (process.env.REACT_APP_SUPERADMIN_EMAIL || '').toLowerCase();
+  const SUPER_ADMIN_PASSWORD = process.env.REACT_APP_SUPERADMIN_PASSWORD || '';
+
   const sendResetEmail = async (email, token) => {
     const link = `${window.location.origin}/#/reset/${token}`;
     try {
@@ -253,7 +256,15 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
   const handleLogin = () => {
     const norm = loginEmail.trim().toLowerCase();
     const pass = loginPassword.trim();
-    if (norm.endsWith('@student.nhlstenden.com')) {
+    if (
+      SUPER_ADMIN_EMAIL &&
+      SUPER_ADMIN_PASSWORD &&
+      norm === SUPER_ADMIN_EMAIL &&
+      pass === SUPER_ADMIN_PASSWORD
+    ) {
+      setLoginError('');
+      onAdminLogin();
+    } else if (norm.endsWith('@student.nhlstenden.com')) {
       const s = students.find((st) => (st.email || '').toLowerCase() === norm);
         if (s && (s.password || '') === pass) {
           setLoginError('');


### PR DESCRIPTION
## Summary
- load environment variables with `dotenv`
- allow super admin login based on env vars
- add default `.env` with mail server and admin credentials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68aed5745b10832ca9d38459011c9998