### PR TITLE
Improve password reset mailer and API handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@tailwindcss/postcss": "^4.1.12",
         "@vitejs/plugin-react": "^5.0.1",
         "autoprefixer": "^10.4.21",
+        "concurrently": "^9.2.1",
         "postcss": "^8.5.6",
         "react-app-rewired": "^2.2.1",
         "tailwindcss": "^3.4.17",
@@ -7161,6 +7162,91 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -16391,6 +16477,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -18239,6 +18335,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/tryer": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "react-app-rewired build",
-    "start": "react-app-rewired start",
+    "start": "concurrently \"react-app-rewired start\" \"node server.js\"",
     "server": "node server.js"
   },
   "browserslist": {
@@ -37,6 +37,7 @@
     "@tailwindcss/postcss": "^4.1.12",
     "@vitejs/plugin-react": "^5.0.1",
     "autoprefixer": "^10.4.21",
+    "concurrently": "^9.2.1",
     "postcss": "^8.5.6",
     "react-app-rewired": "^2.2.1",
     "tailwindcss": "^3.4.17",

--- a/src/App.js
+++ b/src/App.js
@@ -230,13 +230,16 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
   const sendResetEmail = async (email, token) => {
     const link = `${window.location.origin}/#/reset/${token}`;
     try {
-      await fetch('/api/send-reset', {
+      const res = await fetch('/api/send-reset', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, link }),
       });
+      if (!res.ok) throw new Error('response not ok');
+      return true;
     } catch (err) {
       console.error('Failed to send reset email', err);
+      return false;
     }
   };
 
@@ -330,7 +333,7 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
     }
   };
 
-  const handleForgotPassword = () => {
+  const handleForgotPassword = async () => {
     const norm = loginEmail.trim().toLowerCase();
     if (norm.endsWith('@student.nhlstenden.com')) {
       const s = students.find((st) => (st.email || '').toLowerCase() === norm);
@@ -344,8 +347,12 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
           st.id === s.id ? { ...st, resetToken: token } : st
         )
       );
-      sendResetEmail(norm, token);
-      window.alert('Resetlink verstuurd. Controleer je e-mail.');
+      const ok = await sendResetEmail(norm, token);
+      window.alert(
+        ok
+          ? 'Resetlink verstuurd. Controleer je e-mail.'
+          : 'Versturen resetlink mislukt. Probeer opnieuw.'
+      );
     } else if (norm.endsWith('@nhlstenden.com')) {
       const t = teachers.find((te) => te.email.toLowerCase() === norm);
       if (!t) {
@@ -358,8 +365,12 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
           te.id === t.id ? { ...te, resetToken: token } : te
         )
       );
-      sendResetEmail(norm, token);
-      window.alert('Resetlink verstuurd. Controleer je e-mail.');
+      const ok = await sendResetEmail(norm, token);
+      window.alert(
+        ok
+          ? 'Resetlink verstuurd. Controleer je e-mail.'
+          : 'Versturen resetlink mislukt. Probeer opnieuw.'
+      );
     } else {
       setLoginError('Gebruik een geldig e-mailadres.');
     }


### PR DESCRIPTION
## Summary
- start and configure Express server for reset email API
- harden SMTP config and log send results
- handle API errors on reset link and run server + client concurrently

## Testing
- `npm test` (fails: Missing script)
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68aed8832c1c832c8b251f0d915b8793