### PR TITLE
Fix reset email dev setup to avoid port conflict

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ SMTP_USER=minorneuro@gmail.com
 SMTP_PASS=wyiu byak qztt mdjz
 SMTP_FROM=minorneuro@gmail.com
 
-PORT=3001
+SERVER_PORT=3001
 
 SUPERADMIN_EMAIL=admin@nhlstenden.com
 SUPERADMIN_PASSWORD=neuro2025

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "house-of-neuro",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:3001",
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "buffer": "^6.0.3",

--- a/server.js
+++ b/server.js
@@ -51,7 +51,7 @@ app.post('/api/send-reset', async (req, res) => {
   }
 });
 
-const port = process.env.PORT || 3001;
+const port = process.env.SERVER_PORT || 3001;
 app.listen(port, () => {
   console.log(`Email server listening on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- proxy frontend /api requests to the backend for reset emails
- use `SERVER_PORT` env var so backend runs on a separate port from the React dev server

## Testing
- `npm test` (fails: Missing script: "test")
- `npm start` (email server listening on port 3001, dev server booting without port conflict)

------
https://chatgpt.com/codex/tasks/task_e_68aef04f1cac832ca3df51a0f301d944