### PR TITLE
feat: use production domain for reset links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -228,7 +228,8 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
   const SUPER_ADMIN_PASSWORD = process.env.REACT_APP_SUPERADMIN_PASSWORD || '';
 
   const sendResetEmail = async (email, token) => {
-    const link = `${window.location.origin}/#/reset/${token}`;
+    const baseUrl = process.env.REACT_APP_BASE_URL || 'https://minorneuro.nl';
+    const link = `${baseUrl}/#/reset/${token}`;
     try {
       const res = await fetch('/api/send-reset', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- build reset email links with https://minorneuro.nl by default, configurable via `REACT_APP_BASE_URL`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aef3d38660832c94abc0b6e31b036f