### PR TITLE
Show badge instructions and document env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# House of Neuro
+
+This project uses a `.env` file for configuration. The committed `.env` contains placeholder values only.
+
+Replace these placeholders with your real credentials before deploying. Never commit production secrets to the repository—configure them directly in the deployment environment to keep sensitive data out of public git history.

--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -38,15 +38,19 @@ export default function BadgeOverview({ badgeDefs, earnedBadges }) {
 
       {expandedBadge && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
           onClick={() => setExpanded(null)}
         >
-          <img
-            src={expandedBadge.image}
-            alt={expandedBadge.title}
-            className="max-w-full max-h-full cursor-pointer object-contain"
-
-          />
+          <div className="max-h-full overflow-auto text-center" onClick={(e) => e.stopPropagation()}>
+            <img
+              src={expandedBadge.image}
+              alt={expandedBadge.title}
+              className="max-w-full max-h-[80vh] mx-auto object-contain"
+            />
+            {expandedBadge.requirement && (
+              <p className="mt-4 text-white">{expandedBadge.requirement}</p>
+            )}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- display teacher-provided badge instructions when students expand a badge
- document in README that the committed `.env` should be adapted before deployment
- restore the `.env` file to its original local-testing values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0098fe8ac832cb84058085d607247