### PR TITLE
feat: allow configurable API base for reset emails

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,9 @@ SUPERADMIN_EMAIL=admin@nhlstenden.com
 SUPERADMIN_PASSWORD=neuro2025
 REACT_APP_SUPERADMIN_EMAIL=admin@nhlstenden.com
 REACT_APP_SUPERADMIN_PASSWORD=neuro2025
+
+# Base URL used when constructing password reset links
+REACT_APP_BASE_URL=http://localhost:3000
+
+# API server base; leave empty to use the same origin
+REACT_APP_API_BASE=http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This project uses a `.env` file for configuration. The committed `.env` contains placeholder values only.
 
 Replace these placeholders with your real credentials before deploying. Never commit production secrets to the repository—configure them directly in the deployment environment to keep sensitive data out of public git history.
+
+## Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `REACT_APP_BASE_URL` | Base URL of the frontend used when generating password reset links. |
+| `REACT_APP_API_BASE` | Base URL of the API server used to send reset emails. Leave empty to use the same origin. |

--- a/src/App.js
+++ b/src/App.js
@@ -228,10 +228,11 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
   const SUPER_ADMIN_PASSWORD = process.env.REACT_APP_SUPERADMIN_PASSWORD || '';
 
   const sendResetEmail = async (email, token) => {
-    const baseUrl = process.env.REACT_APP_BASE_URL || window.location.origin;
+    const baseUrl = (process.env.REACT_APP_BASE_URL || window.location.origin).replace(/\/$/, '');
     const link = `${baseUrl}/#/reset/${token}`;
     try {
-      const res = await fetch('/api/send-reset', {
+      const apiBase = process.env.REACT_APP_API_BASE || '';
+      const res = await fetch(`${apiBase}/api/send-reset`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, link }),


### PR DESCRIPTION
## Summary
- allow base URLs for the frontend and API to be configured via env vars
- document new env vars

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b01813a094832ca3c61023fb98eee0