### PR TITLE
Remove localhost API override

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -229,9 +229,9 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
 
   const sendResetEmail = async (email, token) => {
     const baseUrl = (process.env.REACT_APP_BASE_URL || window.location.origin).replace(/\/$/, '');
+    let apiBase = process.env.REACT_APP_API_BASE || '';
     const link = `${baseUrl}/#/reset/${token}`;
     try {
-      const apiBase = process.env.REACT_APP_API_BASE || '';
       const res = await fetch(`${apiBase}/api/send-reset`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- always respect `REACT_APP_API_BASE` without localhost override
- restore original `SMTP_PASS` value

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b01ada553c832cb845b8e39ff10cba