### PR TITLE
Normalize API base URL for reset emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Replace these placeholders with your real credentials before deploying. Never co
 | Variable | Purpose |
 | --- | --- |
 | `REACT_APP_BASE_URL` | Base URL of the frontend used when generating password reset links. |
-| `REACT_APP_API_BASE` | Base URL of the API server used to send reset emails. Leave empty to use the same origin. |
+| `REACT_APP_API_BASE` | Base URL of the API server used to send reset emails. Leave empty to use the same origin. Trailing slashes are removed. |


### PR DESCRIPTION
## Summary
- Sanitize `REACT_APP_API_BASE` to drop trailing slashes and generate clean password-reset paths
- Document trailing slash handling for `REACT_APP_API_BASE`
- Add detailed debug info when sending reset emails fails

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0254c5690832caaac475b5c081430