### PR TITLE
Fix reset link domain for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Replace these placeholders with your real credentials before deploying. Never co
 
 | Variable | Purpose |
 | --- | --- |
-| `REACT_APP_BASE_URL` | Base URL of the frontend used when generating password reset links. |
-| `REACT_APP_API_BASE` | Base URL of the API server used to send reset emails. Leave empty to use the same origin. Trailing slashes are removed. |
+| `REACT_APP_BASE_URL` | Base URL of the frontend used when generating password reset links. When the app is served from localhost this value is used; otherwise the current origin is used. |
+| `REACT_APP_API_BASE` | Base URL of the API server used to send reset emails. When running on localhost this value can point to a different server (e.g. `http://localhost:3001`); in production the current origin is used automatically. |

--- a/src/App.js
+++ b/src/App.js
@@ -228,8 +228,9 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
   const SUPER_ADMIN_PASSWORD = process.env.REACT_APP_SUPERADMIN_PASSWORD || '';
 
   const sendResetEmail = async (email, token) => {
-    const baseUrl = (process.env.REACT_APP_BASE_URL || window.location.origin).replace(/\/$/, '');
-    const apiBase = (process.env.REACT_APP_API_BASE || '').replace(/\/$/, '');
+    const isLocal = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const baseUrl = ((isLocal && process.env.REACT_APP_BASE_URL) || window.location.origin).replace(/\/$/, '');
+    const apiBase = ((isLocal && process.env.REACT_APP_API_BASE) || window.location.origin).replace(/\/$/, '');
     const link = `${baseUrl}/#/reset/${token}`;
     const url = `${apiBase}/api/send-reset`;
     try {


### PR DESCRIPTION
## Summary
- Use current origin for password-reset link and API when not on localhost
- Document that REACT_APP_* env vars only apply in local development

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b028f5180c832cb9392c8da5c2897d