### PR TITLE
Revert reset link to earlier implementation

### DIFF
--- a/.env
+++ b/.env
@@ -10,9 +10,3 @@ SUPERADMIN_EMAIL=admin@nhlstenden.com
 SUPERADMIN_PASSWORD=neuro2025
 REACT_APP_SUPERADMIN_EMAIL=admin@nhlstenden.com
 REACT_APP_SUPERADMIN_PASSWORD=neuro2025
-
-# Base URL used when constructing password reset links
-REACT_APP_BASE_URL=http://localhost:3000
-
-# API server base; leave empty to use the same origin
-REACT_APP_API_BASE=http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -3,10 +3,3 @@
 This project uses a `.env` file for configuration. The committed `.env` contains placeholder values only.
 
 Replace these placeholders with your real credentials before deploying. Never commit production secrets to the repository—configure them directly in the deployment environment to keep sensitive data out of public git history.
-
-## Environment variables
-
-| Variable | Purpose |
-| --- | --- |
-| `REACT_APP_BASE_URL` | Base URL of the frontend used when generating password reset links. When the app is served from localhost this value is used; otherwise the current origin is used. |
-| `REACT_APP_API_BASE` | Base URL of the API server used to send reset emails. When running on localhost this value can point to a different server (e.g. `http://localhost:3001`); in production the current origin is used automatically. |

--- a/src/App.js
+++ b/src/App.js
@@ -228,25 +228,18 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
   const SUPER_ADMIN_PASSWORD = process.env.REACT_APP_SUPERADMIN_PASSWORD || '';
 
   const sendResetEmail = async (email, token) => {
-    const isLocal = ['localhost', '127.0.0.1'].includes(window.location.hostname);
-    const baseUrl = ((isLocal && process.env.REACT_APP_BASE_URL) || window.location.origin).replace(/\/$/, '');
-    const apiBase = ((isLocal && process.env.REACT_APP_API_BASE) || window.location.origin).replace(/\/$/, '');
-    const link = `${baseUrl}/#/reset/${token}`;
-    const url = `${apiBase}/api/send-reset`;
+    const link = `${window.location.origin}/#/reset/${token}`;
     try {
-      const res = await fetch(url, {
+      const res = await fetch('/api/send-reset', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, link }),
       });
-      if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        throw new Error(`status ${res.status} ${text}`.trim());
-      }
-      return { ok: true };
+      if (!res.ok) throw new Error('response not ok');
+      return true;
     } catch (err) {
-      console.error('Failed to send reset email', { url, link, error: err });
-      return { ok: false, debug: `url=${url} link=${link} message=${err.message}` };
+      console.error('Failed to send reset email', err);
+      return false;
     }
   };
 
@@ -354,11 +347,11 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
           st.id === s.id ? { ...st, resetToken: token } : st
         )
       );
-      const result = await sendResetEmail(norm, token);
+      const ok = await sendResetEmail(norm, token);
       window.alert(
-        result.ok
+        ok
           ? 'Resetlink verstuurd. Controleer je e-mail.'
-          : `Versturen resetlink mislukt. Probeer opnieuw. (${result.debug})`
+          : 'Versturen resetlink mislukt. Probeer opnieuw.'
       );
     } else if (norm.endsWith('@nhlstenden.com')) {
       const t = teachers.find((te) => te.email.toLowerCase() === norm);
@@ -372,11 +365,11 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
           te.id === t.id ? { ...te, resetToken: token } : te
         )
       );
-      const result = await sendResetEmail(norm, token);
+      const ok = await sendResetEmail(norm, token);
       window.alert(
-        result.ok
+        ok
           ? 'Resetlink verstuurd. Controleer je e-mail.'
-          : `Versturen resetlink mislukt. Probeer opnieuw. (${result.debug})`
+          : 'Versturen resetlink mislukt. Probeer opnieuw.'
       );
     } else {
       setLoginError('Gebruik een geldig e-mailadres.');


### PR DESCRIPTION
## Summary
- restore `sendResetEmail` to use `window.location.origin` and `/api/send-reset`
- remove reset link environment variables from `.env` and docs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b02ca6ef04832cb83fef0a8b08f4f2