### PR TITLE
Add extensive debugging to password reset flow

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,20 +22,41 @@ if (process.env.SMTP_SERVICE) {
 
 const transporter = nodemailer.createTransport(transportConfig);
 
+// Log the SMTP configuration (without password) for easier debugging
+console.debug('SMTP configuration', {
+  host: transportConfig.host,
+  port: transportConfig.port,
+  secure: transportConfig.secure,
+  service: transportConfig.service,
+  user: transportConfig.auth && transportConfig.auth.user,
+  from: process.env.SMTP_FROM || process.env.SMTP_USER,
+});
+
+// Verify the connection to the SMTP server so issues are surfaced early
+transporter
+  .verify()
+  .then(() => console.log('SMTP connection verified'))
+  .catch((err) => console.error('SMTP verify failed', err));
+
 if (
   process.env.SMTP_FROM &&
   process.env.SMTP_USER &&
   process.env.SMTP_FROM !== process.env.SMTP_USER
 ) {
-  console.warn('SMTP_FROM differs from SMTP_USER; some providers may reject the message');
+  console.warn(
+    'SMTP_FROM differs from SMTP_USER; some providers may reject the message'
+  );
 }
 
 app.post('/api/send-reset', async (req, res) => {
   const { email, link } = req.body || {};
+  console.debug('Incoming reset request', { email, link });
   if (!email || !link) {
+    console.warn('Missing email or link in reset request');
     return res.status(400).json({ error: 'missing email or link' });
   }
   try {
+    console.debug('Sending reset email', { to: email });
     const info = await transporter.sendMail({
       from: process.env.SMTP_FROM || process.env.SMTP_USER,
       to: email,
@@ -43,7 +64,12 @@ app.post('/api/send-reset', async (req, res) => {
       text: `Gebruik de volgende link om je wachtwoord te resetten: ${link}`,
       html: `<p>Gebruik de volgende link om je wachtwoord te resetten:</p><p><a href="${link}">${link}</a></p>`,
     });
-    console.log('Mail send result', info.accepted, info.rejected);
+    console.debug('Mail send result', {
+      accepted: info.accepted,
+      rejected: info.rejected,
+      response: info.response,
+      messageId: info.messageId,
+    });
     res.json({ ok: true });
   } catch (err) {
     console.error('Failed to send email', err);


### PR DESCRIPTION
## Summary
- enhance SMTP configuration logging and connection verification
- add detailed logs for password reset API requests
- include client-side debugging for reset email sending, token lookup, and password update

## Testing
- `npm run build`
- `node server.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b03925db90832c95c6a34ed54668a6