### PR TITLE
Add student profile page and enable Enter key login

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=465         # SSL
 SMTP_USER=minorneuro@gmail.com
-SMTP_PASS=wyiu byak qztt mdjz
+SMTP_PASS=placeholdercode
 SMTP_FROM=minorneuro@gmail.com
 
 SERVER_PORT=3001

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -65,15 +65,20 @@ export default function Admin({ onLogout = () => {} }) {
     setStudents((prev) => prev.filter((s) => s.id !== id));
   }, [setStudents]);
 
-  const resetStudentPassword = useCallback((id) => {
-    const code = Math.random().toString(36).slice(2, 8);
-    setStudents((prev) =>
-      prev.map((s) =>
-        s.id === id ? { ...s, password: '', tempCode: code } : s
-      )
-    );
-    window.alert(`Nieuwe code: ${code}`);
-  }, [setStudents]);
+  const resetStudentPassword = useCallback(
+    (id) => {
+      const pwd = window.prompt('Nieuw wachtwoord:');
+      if (!pwd?.trim()) return;
+      setStudents((prev) =>
+        prev.map((s) =>
+          s.id === id
+            ? { ...s, password: pwd.trim(), tempCode: undefined }
+            : s
+        )
+      );
+    },
+    [setStudents]
+  );
 
   const addGroup = useCallback((name) => {
     const id = genId();

--- a/src/App.js
+++ b/src/App.js
@@ -65,25 +65,26 @@ export default function App() {
               }}
             />
           )
-        ) : route === '/student' ? (
-          selectedStudentId ? (
-            <Student
-              selectedStudentId={selectedStudentId}
-              setSelectedStudentId={setSelectedStudentId}
-            />
-          ) : (
-            <Auth
-              onAdminLogin={() => {
-                allowAdmin();
-                window.location.hash = '/admin';
-              }}
-              onStudentLogin={(id) => {
-                setSelectedStudentId(id);
-                window.location.hash = '/student';
-              }}
-            />
-          )
-        ) : route === '/roster' ? (
+          ) : route.startsWith('/student') ? (
+            selectedStudentId ? (
+              <Student
+                selectedStudentId={selectedStudentId}
+                setSelectedStudentId={setSelectedStudentId}
+                route={route}
+              />
+            ) : (
+              <Auth
+                onAdminLogin={() => {
+                  allowAdmin();
+                  window.location.hash = '/admin';
+                }}
+                onStudentLogin={(id) => {
+                  setSelectedStudentId(id);
+                  window.location.hash = '/student';
+                }}
+              />
+            )
+          ) : route === '/roster' ? (
           isAdmin ? (
             <AdminRoster />
           ) : (
@@ -477,13 +478,14 @@ function Auth({ onStudentLogin, onAdminLogin, resetToken }) {
                 placeholder="E-mail"
                 className="mb-2"
               />
-              <TextInput
-                type="password"
-                value={loginPassword}
-                onChange={setLoginPassword}
-                placeholder="Wachtwoord"
-                className="mb-4"
-              />
+                <TextInput
+                  type="password"
+                  value={loginPassword}
+                  onChange={setLoginPassword}
+                  onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
+                  placeholder="Wachtwoord"
+                  className="mb-4"
+                />
               {loginError && (
                 <div className="text-sm text-rose-600 mb-2">{loginError}</div>
               )}

--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -22,12 +22,20 @@ export function Button({ children, onClick, type = 'button', className = '', dis
   );
 }
 
-export function TextInput({ value, onChange, placeholder, type = 'text', className = '' }) {
+export function TextInput({
+  value,
+  onChange,
+  placeholder,
+  type = 'text',
+  className = '',
+  onKeyDown,
+}) {
   return (
     <input
       type={type}
       value={value}
       onChange={(e) => onChange(e.target.value)}
+      onKeyDown={onKeyDown}
       placeholder={placeholder}
       className={`w-full ${className}`}
     />

--- a/src/data/students.json
+++ b/src/data/students.json
@@ -1,5 +1,5 @@
 [
-  { "id": "s1", "name": "Alex",  "email": "alex@student.nhlstenden.com",  "password": "1234", "groupId": "g1", "points": 10, "badges": [] },
-  { "id": "s2", "name": "Bo",    "email": "bo@student.nhlstenden.com",    "password": "1234", "groupId": "g1", "points": 5,  "badges": [] },
-  { "id": "s3", "name": "Casey", "email": "casey@student.nhlstenden.com", "password": "1234", "groupId": "g2", "points": 12, "badges": [] }
+  { "id": "s1", "name": "Alex",  "email": "alex@student.nhlstenden.com",  "password": "1234", "groupId": "g1", "points": 10, "badges": [], "photo": "" },
+  { "id": "s2", "name": "Bo",    "email": "bo@student.nhlstenden.com",    "password": "1234", "groupId": "g1", "points": 5,  "badges": [], "photo": "" },
+  { "id": "s3", "name": "Casey", "email": "casey@student.nhlstenden.com", "password": "1234", "groupId": "g2", "points": 12, "badges": [], "photo": "" }
 ]


### PR DESCRIPTION
## Summary
- allow students to edit their name, password and profile photo on a new "Mijn profiel" page
- persist profile photos for students
- submit login forms with the Enter key
- manually set new passwords for students from the admin panel
- replace SMTP password with placeholder value

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b040445a14832ca6e67bde48279fb7