### PR TITLE
Add score overview to admin panel

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -249,6 +249,7 @@ export default function Admin({ onLogout = () => {} }) {
   }, [students, previewId]);
 
   const menuItems = [
+    { value: 'scores', label: 'Scores' },
     { value: 'points', label: 'Punten invoeren' },
     { value: 'badges', label: 'Badges toekennen' },
     { value: 'manage-groups', label: 'Groepen beheren' },
@@ -282,6 +283,76 @@ export default function Admin({ onLogout = () => {} }) {
             Uitloggen
           </Button>
         </div>
+
+      {page === 'scores' && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card title="Leaderboard – Individueel">
+            <table className="w-full text-sm whitespace-nowrap">
+              <thead>
+                <tr className="text-left border-b">
+                  <th className="py-1 pr-2">#</th>
+                  <th className="py-1 pr-2">Student</th>
+                  <th className="py-1 pr-2">Groep</th>
+                  <th className="py-1 pr-2 text-right">Punten</th>
+                </tr>
+              </thead>
+              <tbody>
+                {individualLeaderboard.map((row) => (
+                  <tr key={row.id} className="border-b last:border-0">
+                    <td className="py-1 pr-2">{row.rank}</td>
+                    <td className="py-1 pr-2">{row.name}</td>
+                    <td className="py-1 pr-2">
+                      {row.groupId ? groupById.get(row.groupId)?.name || '-' : '-'}
+                    </td>
+                    <td
+                      className={`py-1 pr-2 text-right font-semibold ${
+                        row.points > 0
+                          ? 'text-emerald-700'
+                          : row.points < 0
+                          ? 'text-rose-700'
+                          : 'text-neutral-700'
+                      }`}
+                    >
+                      {row.points}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Card>
+
+          <Card title="Leaderboard – Groepen">
+            <table className="w-full text-sm whitespace-nowrap">
+              <thead>
+                <tr className="text-left border-b">
+                  <th className="py-1 pr-2">#</th>
+                  <th className="py-1 pr-2">Groep</th>
+                  <th className="py-1 pr-2 text-right">Totaal</th>
+                </tr>
+              </thead>
+              <tbody>
+                {groupLeaderboard.map((row) => (
+                  <tr key={row.id} className="border-b last:border-0">
+                    <td className="py-1 pr-2">{row.rank}</td>
+                    <td className="py-1 pr-2">{row.name}</td>
+                    <td
+                      className={`py-1 pr-2 text-right font-semibold ${
+                        row.total > 0
+                          ? 'text-emerald-700'
+                          : row.total < 0
+                          ? 'text-rose-700'
+                          : 'text-neutral-700'
+                      }`}
+                    >
+                      {row.total}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Card>
+        </div>
+      )}
 
       {page === 'manage-students' && (
         <Card title="Studenten beheren">


### PR DESCRIPTION
## Summary
- Add new Scores page to admin panel
- Show full individual and group leaderboards for admins

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b044cd8a78832ca6a1fda3204c3c33