### PR TITLE
hash student passwords

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -55,9 +55,10 @@ export default function Admin({ onLogout = () => {} }) {
 
   const addStudent = useCallback((name, email, password = '') => {
     const id = genId();
+    const hash = bcrypt.hashSync(password, 10);
     setStudents((prev) => [
       ...prev,
-      { id, name, email: email || undefined, password, groupId: null, points: 0, badges: [] }
+      { id, name, email: email || undefined, password: hash, groupId: null, points: 0, badges: [] }
     ]);
     return id;
   }, [setStudents]);
@@ -70,10 +71,11 @@ export default function Admin({ onLogout = () => {} }) {
     (id) => {
       const pwd = window.prompt('Nieuw wachtwoord:');
       if (!pwd?.trim()) return;
+      const hash = bcrypt.hashSync(pwd.trim(), 10);
       setStudents((prev) =>
         prev.map((s) =>
           s.id === id
-            ? { ...s, password: pwd.trim(), tempCode: undefined }
+            ? { ...s, password: hash, tempCode: undefined }
             : s
         )
       );


### PR DESCRIPTION
## Summary
- hash and verify student passwords using bcrypt across signup, login, profile update and reset flows
- ensure admin tools hash student passwords when creating or resetting accounts

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3150bdd30832cb52331a42ce41588