### PR TITLE
Fix student login race condition

### DIFF
--- a/src/Student.js
+++ b/src/Student.js
@@ -48,8 +48,11 @@ export default function Student({
   }, [setStudents]);
 
   useEffect(() => {
-    if (!inPreview && selectedStudentId && !students.find((s) => s.id === selectedStudentId)) {
-      setSelectedStudentId('');
+    if (!inPreview && selectedStudentId) {
+      const exists = students.some((s) => s.id === selectedStudentId);
+      if (students.length > 0 && !exists) {
+        setSelectedStudentId('');
+      }
     }
   }, [students, selectedStudentId, setSelectedStudentId, inPreview]);
 


### PR DESCRIPTION
## Summary
- Avoid resetting student session before student data loads

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b337bf09f8832c88ad78d0ac96a5dc