### PR TITLE
Fix badge image uploads in admin

### DIFF
--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1,5 +1,4 @@
 import { createClient } from '@supabase/supabase-js';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 
 const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
 const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
@@ -7,35 +6,17 @@ const supabaseBucket = process.env.REACT_APP_SUPABASE_BUCKET || 'hon';
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-const s3 = new S3Client({
-  region: 'us-east-1',
-  endpoint: process.env.REACT_APP_SUPABASE_S3_ENDPOINT,
-  credentials: {
-    accessKeyId: process.env.REACT_APP_SUPABASE_S3_ACCESS_KEY_ID,
-    secretAccessKey: process.env.REACT_APP_SUPABASE_S3_SECRET_ACCESS_KEY,
-  },
-  forcePathStyle: true,
-});
-
 export const getImageUrl = (path) =>
   `${supabaseUrl}/storage/v1/object/public/${supabaseBucket}/images/${path}`;
 
 export async function uploadImage(file) {
   const ext = file.name.split('.').pop();
   const name = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
-  const key = `images/${name}`;
-  try {
-    await s3.send(
-      new PutObjectCommand({
-        Bucket: supabaseBucket,
-        Key: key,
-        Body: file,
-        ContentType: file.type,
-      })
-    );
-    return getImageUrl(name);
-  } catch (error) {
+  const path = `images/${name}`;
+  const { error } = await supabase.storage.from(supabaseBucket).upload(path, file);
+  if (error) {
     console.error('Error uploading image', error);
     return null;
   }
+  return getImageUrl(name);
 }


### PR DESCRIPTION
## Summary
- upload badge images using Supabase storage API instead of AWS S3

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b342f08180832c8c3a45da2b2da29c