### PR TITLE
Improve image upload error handling

### DIFF
--- a/src/supabase.js
+++ b/src/supabase.js
@@ -10,13 +10,25 @@ export const getImageUrl = (path) =>
   `${supabaseUrl}/storage/v1/object/public/${supabaseBucket}/images/${path}`;
 
 export async function uploadImage(file) {
+  if (!file) return null;
+
   const ext = file.name.split('.').pop();
   const name = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
   const path = `images/${name}`;
-  const { error } = await supabase.storage.from(supabaseBucket).upload(path, file);
+
+  const { error } = await supabase.storage
+    .from(supabaseBucket)
+    .upload(path, file, {
+      cacheControl: '3600',
+      upsert: true,
+      contentType: file.type,
+    });
+
   if (error) {
     console.error('Error uploading image', error);
+    alert('Afbeelding uploaden mislukt. Controleer de Supabase configuratie.');
     return null;
   }
+
   return getImageUrl(name);
 }


### PR DESCRIPTION
## Summary
- add error handling and upsert options when uploading images to Supabase

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b34527c218832c9461177cf974105e