### PR TITLE
Fix badge image upload via Supabase S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ Set the following in `.env` before running the app:
 ```
 REACT_APP_SUPABASE_URL=https://rgyukpzginlyihyijbfk.supabase.co
 REACT_APP_SUPABASE_ANON_KEY=<your-anon-key>
-REACT_APP_SUPABASE_BUCKET=hon
 REACT_APP_SUPABASE_S3_ENDPOINT=https://rgyukpzginlyihyijbfk.storage.supabase.co/storage/v1/s3
 REACT_APP_SUPABASE_S3_ACCESS_KEY_ID=<your-s3-access-key-id>
 REACT_APP_SUPABASE_S3_SECRET_ACCESS_KEY=<your-s3-secret-access-key>
 ```
 
+The S3 credentials are used for uploading badge images via the S3
+compatibility API.
+
 ## Database setup
 Use the SQL in [`supabase-schema.sql`](./supabase-schema.sql) in the Supabase SQL editor to create the required tables and seed badge definitions. The tables store all students, groups, awards, teachers and badges. Authentication for both students and teachers is performed against these tables.
 
 ## Storage bucket
-Create a public storage bucket named `hon` and upload badge images under an `images/` folder. The client builds public URLs at runtime via Supabase storage.
+Create a public storage bucket named `hon` and upload badge images under an `images/` folder. The client is hard-coded to use this bucket when generating URLs and uploading files.

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1,10 +1,26 @@
 import { createClient } from '@supabase/supabase-js';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 
 const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
 const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
-const supabaseBucket = process.env.REACT_APP_SUPABASE_BUCKET || 'hon';
+// Storage bucket for badge images
+const supabaseBucket = 'hon';
+
+const s3Endpoint = process.env.REACT_APP_SUPABASE_S3_ENDPOINT;
+const s3AccessKeyId = process.env.REACT_APP_SUPABASE_S3_ACCESS_KEY_ID;
+const s3SecretAccessKey = process.env.REACT_APP_SUPABASE_S3_SECRET_ACCESS_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+const s3Client = new S3Client({
+  region: 'us-east-1',
+  endpoint: s3Endpoint,
+  credentials: {
+    accessKeyId: s3AccessKeyId,
+    secretAccessKey: s3SecretAccessKey,
+  },
+  forcePathStyle: true,
+});
 
 export const getImageUrl = (path) =>
   `${supabaseUrl}/storage/v1/object/public/${supabaseBucket}/images/${path}`;
@@ -14,17 +30,17 @@ export async function uploadImage(file) {
 
   const ext = file.name.split('.').pop();
   const name = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
-  const path = `images/${name}`;
+  const key = `images/${name}`;
 
-  const { error } = await supabase.storage
-    .from(supabaseBucket)
-    .upload(path, file, {
-      cacheControl: '3600',
-      upsert: true,
-      contentType: file.type,
+  try {
+    const command = new PutObjectCommand({
+      Bucket: supabaseBucket,
+      Key: key,
+      Body: file,
+      ContentType: file.type,
     });
-
-  if (error) {
+    await s3Client.send(command);
+  } catch (error) {
     console.error('Error uploading image', error);
     alert('Afbeelding uploaden mislukt. Controleer de Supabase configuratie.');
     return null;


### PR DESCRIPTION
## Summary
- Switch badge image uploads to use Supabase's S3-compatible API
- Document S3 credentials required for image uploads
- Hard-code storage bucket name to `hon`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b347e2e588832c9c11f8b753a9e277