### PR TITLE
Improve badge management and Supabase upload debugging

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -179,11 +179,16 @@ export default function Admin({ onLogout = () => {} }) {
 
   const addBadge = useCallback(() => {
     const title = newBadgeTitle.trim();
-    if (!title || !newBadgeImage) return;
+    if (!title) return;
     const id = genId();
     setBadgeDefs((prev) => [
       ...prev,
-      { id, title, image: newBadgeImage, requirement: newBadgeRequirement.trim() },
+      {
+        id,
+        title,
+        image: newBadgeImage || '',
+        requirement: newBadgeRequirement.trim(),
+      },
     ]);
     setNewBadgeTitle('');
     setNewBadgeImage('');
@@ -664,7 +669,7 @@ export default function Admin({ onLogout = () => {} }) {
               )}
             <Button
                 className="bg-indigo-600 text-white"
-                disabled={!newBadgeTitle.trim() || !newBadgeImage}
+                disabled={!newBadgeTitle.trim()}
                 onClick={addBadge}
               >
                 Maak badge

--- a/src/components/BadgeOverview.js
+++ b/src/components/BadgeOverview.js
@@ -11,11 +11,11 @@ export default function BadgeOverview({ badgeDefs, earnedBadges }) {
       <div className="badge-stack">
         {badgeDefs.map((b) => {
           const earned = earnedBadges.includes(b.id);
-          const req = b.requirement || '';
-          const fontSize = Math.max(8, 14 - req.length / 5);
+          const text = earned ? b.title : b.requirement || '';
+          const fontSize = Math.max(8, 14 - text.length / 5);
           return (
             <div key={b.id} className="badge-box relative z-0 hover:z-10">
-              {earned ? (
+              {earned && b.image ? (
                 <img
                   src={b.image}
                   alt={b.title}
@@ -27,7 +27,7 @@ export default function BadgeOverview({ badgeDefs, earnedBadges }) {
                   className="w-full h-full rounded-full border bg-white flex items-center justify-center text-center p-1 break-words leading-tight"
                   style={{ fontSize: `${fontSize}px` }}
                 >
-                  {req}
+                  {text}
                 </div>
               )}
             </div>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -15,8 +15,10 @@ export async function uploadImage(file) {
 
   const { data: user, error: userError } = await supabase.auth.getUser();
   if (userError || !user?.user) {
-    console.error('No Supabase user', userError);
-    alert('Afbeelding uploaden mislukt. Controleer de Supabase configuratie.');
+    console.error('No Supabase user', { userError, user });
+    alert(
+      `Afbeelding uploaden mislukt: geen Supabase gebruiker gevonden (${userError?.message})`
+    );
     return null;
   }
 
@@ -33,8 +35,8 @@ export async function uploadImage(file) {
     });
 
   if (error) {
-    console.error('Error uploading image', error);
-    alert('Afbeelding uploaden mislukt. Controleer de Supabase configuratie.');
+    console.error('Error uploading image', { error, filePath, file });
+    alert(`Afbeelding uploaden mislukt: ${error.message}`);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- allow creating badges without an image and update UI accordingly
- show badge titles if no image is present in overview
- add detailed debugging when Supabase image upload fails

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b351656c28832c86a3575e54577085