### PR TITLE
feat: support anonymous Supabase uploads

### DIFF
--- a/src/supabase.js
+++ b/src/supabase.js
@@ -5,7 +5,23 @@ const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
 // Storage bucket for badge images
 const supabaseBucket = 'hon';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    storage: typeof window !== 'undefined' ? window.localStorage : undefined,
+  },
+});
+
+async function ensureSession() {
+  const { data } = await supabase.auth.getSession();
+  if (data.session) return data.session;
+
+  const { data: anon, error } = await supabase.auth.signInAnonymously();
+  if (error) throw new Error(`Anonymous sign-in failed: ${error.message}`);
+  return anon.session;
+}
 
 export const getImageUrl = (path) =>
   `${supabaseUrl}/storage/v1/object/public/${supabaseBucket}/images/${path}`;
@@ -13,18 +29,20 @@ export const getImageUrl = (path) =>
 export async function uploadImage(file) {
   if (!file) return null;
 
-  const { data: user, error: userError } = await supabase.auth.getUser();
-  if (userError || !user?.user) {
-    console.error('No Supabase user', { userError, user });
+  await ensureSession();
+
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (userError || !userData?.user) {
+    console.error('No Supabase user', { userError, user: userData });
     alert(
       `Afbeelding uploaden mislukt: geen Supabase gebruiker gevonden (${userError?.message})`
     );
     return null;
   }
 
-  const ext = file.name.split('.').pop();
-  const name = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
-  const filePath = `images/${name}`;
+  const uid = userData.user.id;
+  const ext = file.name.split('.').pop() || 'jpg';
+  const filePath = `${uid}/badges/${Date.now()}.${ext}`;
 
   const { error } = await supabase.storage
     .from(supabaseBucket)
@@ -40,5 +58,6 @@ export async function uploadImage(file) {
     return null;
   }
 
-  return getImageUrl(name);
+  const { data } = supabase.storage.from(supabaseBucket).getPublicUrl(filePath);
+  return data.publicUrl;
 }


### PR DESCRIPTION
## Summary
- ensure a Supabase session by signing in anonymously when necessary
- persist sessions and upload badge images to user-specific storage paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b353a31030832c8f32e9fb1fd296be