### PR TITLE
Handle award amount as string in Admin award form

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -170,7 +170,7 @@ export default function Admin({ onLogout = () => {} }) {
   const [awardType, setAwardType] = useState('student');
   const [awardStudentIds, setAwardStudentIds] = useState(students[0] ? [students[0].id] : []);
   const [awardGroupId, setAwardGroupId] = useState(groups[0]?.id || '');
-  const [awardAmount, setAwardAmount] = useState(5);
+  const [awardAmount, setAwardAmount] = useState('5');
   const [awardReason, setAwardReason] = useState('');
 
   const [newBadgeTitle, setNewBadgeTitle] = useState('');
@@ -813,7 +813,7 @@ export default function Admin({ onLogout = () => {} }) {
 
             <div>
               <label className="text-sm">Punten</label>
-              <TextInput value={String(awardAmount)} onChange={(v) => setAwardAmount(Number(v))} />
+              <TextInput value={awardAmount} onChange={setAwardAmount} />
             </div>
             <div className="md:col-span-2">
               <label className="text-sm">Reden</label>
@@ -823,12 +823,18 @@ export default function Admin({ onLogout = () => {} }) {
               className="bg-indigo-600 text-white md:col-span-5"
               disabled={awardType === 'student' ? awardStudentIds.length === 0 : !awardGroupId}
               onClick={() => {
+                const amount = Number(awardAmount);
+                if (!Number.isFinite(amount)) {
+                  alert('Ongeldige waarde');
+                  return;
+                }
                 if (awardType === 'student') {
-                  awardStudentIds.forEach((id) => awardToStudent(id, awardAmount, awardReason.trim()));
+                  awardStudentIds.forEach((id) => awardToStudent(id, amount, awardReason.trim()));
                 } else {
-                  awardToGroup(awardGroupId, awardAmount, awardReason.trim());
+                  awardToGroup(awardGroupId, amount, awardReason.trim());
                 }
                 setAwardReason('');
+                setAwardAmount('');
               }}
             >
               Toekennen

--- a/src/hooks/useSupabaseTable.js
+++ b/src/hooks/useSupabaseTable.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { supabase } from '../supabase';
+import { supabase, ensureSession } from '../supabase';
 
 export default function useSupabaseTable(table, { autoSave = true } = {}) {
   const [data, setData] = useState([]);
@@ -10,6 +10,7 @@ export default function useSupabaseTable(table, { autoSave = true } = {}) {
   useEffect(() => {
     let ignore = false;
     async function fetchData() {
+      await ensureSession();
       const { data: rows, error } = await supabase.from(table).select('*');
       if (!ignore) {
         if (error) {
@@ -34,6 +35,7 @@ export default function useSupabaseTable(table, { autoSave = true } = {}) {
 
   const save = useCallback(async () => {
     if (!loaded || !dirty) return;
+    await ensureSession();
     const ids = new Set(data.map((r) => r.id));
     const toDelete = [...prevIds.current].filter((id) => !ids.has(id));
     if (toDelete.length) {

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -14,7 +14,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   },
 });
 
-async function ensureSession() {
+export async function ensureSession() {
   const { data } = await supabase.auth.getSession();
   if (data.session) return data.session;
 


### PR DESCRIPTION
## Summary
- keep awardAmount as a string to avoid NaN states
- convert and validate award amount when granting points
- ensure Supabase session is established before reading/writing award records so student activity lists populate

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9723a47a4832c8ee19b13a277b9f7