### PR TITLE
Use snake_case award fields

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -120,9 +120,9 @@ export default function Admin({ onLogout = () => {} }) {
       const badgeTitle = badgeDefs.find((b) => b.id === badgeId)?.title || badgeId;
       const award = {
         id: genId(),
-        ts: Date.now(),
-        type: 'student',
-        targetId: studentId,
+        ts: new Date().toISOString(),
+        target: 'student',
+        target_id: studentId,
         amount: delta,
         reason: `Badge ${badgeTitle}`,
       };
@@ -139,9 +139,9 @@ export default function Admin({ onLogout = () => {} }) {
     );
     const award = {
       id: genId(),
-      ts: Date.now(),
-      type: 'student',
-      targetId: studentId,
+      ts: new Date().toISOString(),
+      target: 'student',
+      target_id: studentId,
       amount,
       reason,
     };
@@ -157,9 +157,9 @@ export default function Admin({ onLogout = () => {} }) {
     );
     const award = {
       id: genId(),
-      ts: Date.now(),
-      type: 'group',
-      targetId: groupId,
+      ts: new Date().toISOString(),
+      target: 'group',
+      target_id: groupId,
       amount,
       reason,
     };

--- a/src/Student.js
+++ b/src/Student.js
@@ -64,10 +64,10 @@ export default function Student({
     return awards
       .filter(
         (a) =>
-          (a.type === 'student' && String(a.targetId) === activeStudentId) ||
-          (a.type === 'group' && myGroup && String(a.targetId) === myGroup.id)
+          (a.target === 'student' && String(a.target_id) === activeStudentId) ||
+          (a.target === 'group' && myGroup && String(a.target_id) === myGroup.id)
       )
-      .sort((a, b) => Number(b.ts) - Number(a.ts))
+      .sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
       .slice(0, 20);
   }, [awards, activeStudentId, myGroup]);
 
@@ -481,7 +481,7 @@ export default function Student({
                 {myAwards.map((a) => (
                   <li key={a.id} className="flex justify-between gap-2">
                     <span>
-                      {new Date(Number(a.ts)).toLocaleString()} · {a.type === 'student' ? 'Individueel' : `Groep (${myGroup?.name || '-'})`}{' '}
+                      {new Date(a.ts).toLocaleString()} · {a.target === 'student' ? 'Individueel' : `Groep (${myGroup?.name || '-'})`}{' '}
                       {a.reason ? `— ${a.reason}` : ''}
                     </span>
                     <span className={`font-semibold ${a.amount >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>{a.amount >= 0 ? '+' : ''}{a.amount}</span>

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -21,10 +21,10 @@ create table if not exists groups (
 );
 
 create table if not exists awards (
-  id text primary key,
-  ts bigint,
-  type text check (type in ('student','group')),
-  "targetId" text,
+  id uuid primary key default gen_random_uuid(),
+  ts timestamptz not null default now(),
+  target text check (target in ('student','group')),
+  target_id uuid not null,
   amount integer,
   reason text
 );


### PR DESCRIPTION
## Summary
- use `target`/`target_id` in awards instead of `type`/`targetId`
- store award timestamps as ISO strings
- update Supabase schema to match new columns

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bddff6a958832ca09e2afe28ad78b2