### PR TITLE
Fix login screen background and alphabetize admin options

### DIFF
--- a/src/components/BadgeChecklist.js
+++ b/src/components/BadgeChecklist.js
@@ -1,9 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+
+const badgeCollator = new Intl.Collator('nl', { sensitivity: 'base', numeric: true });
+
+const normalizeTitle = (value, fallback = '') => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || fallback;
+  }
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+  const stringValue = String(value).trim();
+  return stringValue || fallback;
+};
 
 export default function BadgeChecklist({ badgeDefs, studentBadges, onToggle }) {
+  const sortedBadges = useMemo(() => {
+    if (!Array.isArray(badgeDefs)) return [];
+    return [...badgeDefs].sort((a, b) =>
+      badgeCollator.compare(
+        normalizeTitle(a?.title, normalizeTitle(a?.id)),
+        normalizeTitle(b?.title, normalizeTitle(b?.id))
+      )
+    );
+  }, [badgeDefs]);
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-      {badgeDefs.map((b) => (
+      {sortedBadges.map((b) => (
         <label key={b.id} className="flex items-center gap-2 text-sm">
           <input
             type="checkbox"


### PR DESCRIPTION
## Summary
- remove the voorpagina hero image so the login screen shows immediately on load
- alphabetize student, group, and badge selections across admin tools for consistent dropdown ordering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e62bea81dc832c818938c9e13a43bc