### PR TITLE
Prevent blank pages caused by stale service worker caches

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,31 +1,31 @@
-const CACHE_NAME = 'house-of-neuro-cache-v1';
-const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/icon.svg'
-];
+// This worker intentionally removes the old offline cache.
+//
+// Previous releases cached `/` and `/index.html` indefinitely. After a deploy,
+// that HTML could still refer to JavaScript bundles that no longer existed,
+// leaving visitors with only the page background. Keep this file as a cleanup
+// worker so browsers that still have the old worker installed can recover.
+const APP_CACHE_PREFIX = 'house-of-neuro-cache-';
 
-self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE))
-  );
+self.addEventListener('install', () => {
+  self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((cacheNames) =>
-      Promise.all(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(
         cacheNames
-          .filter((name) => name !== CACHE_NAME)
+          .filter((name) => name.startsWith(APP_CACHE_PREFIX))
           .map((name) => caches.delete(name))
-      )
-    )
-  );
-});
+      );
 
-self.addEventListener('fetch', (event) => {
-  event.respondWith(
-    caches.match(event.request).then((response) => response || fetch(event.request))
+      await self.registration.unregister();
+
+      // Reload pages that may have been supplied by the old cache. Without
+      // this, an already-open blank page would only recover on its next reload.
+      const clients = await self.clients.matchAll({ type: 'window' });
+      await Promise.all(clients.map((client) => client.navigate(client.url)));
+    })()
   );
 });

--- a/src/index.js
+++ b/src/index.js
@@ -12,22 +12,30 @@ root.render(
   </React.StrictMode>
 );
 
-// Only register the service worker in production to avoid dev caching issues.
+// Older versions cached index.html indefinitely. That can leave the HTML
+// pointing at bundles removed by a later deployment and results in a blank
+// page. The application does not require offline support, so remove any old
+// registration and its app-specific caches instead of risking stale releases.
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    if (process.env.NODE_ENV === 'production') {
-      navigator.serviceWorker
-        .register('/service-worker.js')
-        .catch((err) =>
-          console.error('Service worker registration failed:', err)
-        );
-    } else {
-      navigator.serviceWorker
-        .getRegistrations()
-        .then((regs) => regs.forEach((reg) => reg.unregister()))
-        .catch((err) =>
-          console.error('Service worker unregister failed:', err)
-        );
+    navigator.serviceWorker
+      .getRegistrations()
+      .then((registrations) =>
+        Promise.all(registrations.map((registration) => registration.unregister()))
+      )
+      .catch((err) => console.error('Service worker cleanup failed:', err));
+
+    if ('caches' in window) {
+      caches
+        .keys()
+        .then((cacheNames) =>
+          Promise.all(
+            cacheNames
+              .filter((name) => name.startsWith('house-of-neuro-cache-'))
+              .map((name) => caches.delete(name))
+          )
+        )
+        .catch((err) => console.error('App cache cleanup failed:', err));
     }
   });
 }


### PR DESCRIPTION
### Motivation
- Users could see a light-blue blank page because an old cache-first service worker kept `/` and `/index.html` indefinitely, causing deployed HTML to reference missing hashed bundles.  
- Clearing site data removed the service worker cache and restored the site, so the fix must remove or neutralize the stale worker and its caches.

### Description
- Replace the old offline service worker with a cleanup worker (`public/service-worker.js`) that immediately activates, deletes caches whose names start with `house-of-neuro-cache-`, unregisters itself, and reloads open pages.  
- Stop registering a new service worker from the app and instead, on page load, unregister any existing service workers and delete app caches that start with `house-of-neuro-cache-` in `src/index.js`.  
- Add comments explaining the root cause and the rationale for removing offline support to avoid future stale-release blank pages.  
- Commit message recorded as `Prevent stale service worker blank pages` and changes applied to `public/service-worker.js` and `src/index.js`.

### Testing
- Ran the test suite with `npx react-app-rewired test --watchAll=false`, which completed with **12 test suites and 77 tests passed**.  
- Built a production bundle with `npm run build`, which completed successfully and produced the optimized `build` output.  
- Ran `git diff --check` and checked the working tree; no whitespace/patch issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e4a853f68832c85f11009084c49f3)